### PR TITLE
Compatibility with Sylius 1.14 - Autoconfigure services that implemen…

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -28,3 +28,4 @@ services:
             -   name: sylius.grid_filter
                 type: etl_execution_name
                 form_type: 'Oliverde8\PhpEtlSyliusAdminBundle\Form\Type\Filter\EtlExecutionNameFilterType'
+        autoconfigure: false


### PR DESCRIPTION
Compatibility with Sylius 1.14 : Autoconfigure services that implements FilterInterface generates an errors with sylius.grid_filter tags because Sylius\Bundle\GridBundle\DependencyInjection\SyliusGridExtension automatically adds a tag without the type attribute